### PR TITLE
Fix issue with "empty" `source` section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
   name: inkscape
   version: {{ version }}
 
-source:
+source:  # [win]
   fn: Inkscape-{{ version }}-1.7z  # [win]
   url: https://inkscape.org/en/gallery/item/3938/Inkscape-{{ version }}-1-win64.7z  # [win64]
   sha1: 724707f66aa48be0a5746d71da5bf328cb2745bf  # [win64]


### PR DESCRIPTION
When `conda-build` resolves a recipe, it first handles all of the selectors. For this recipe on Unix platforms, it results in simply the `source` key with an empty string. Now `conda-build` can run through this fine as it notices the `skip` and steers clear. However, many of our stop `conda-build` from doing this so we can get some information about the sections via `conda-build`. An example of this is our team update script, which parses the recipe for new maintainers. While it initially processed the `meta.yaml` file directly, it required more and more sophistication to handle and preprocess jinja. In the `meta.yaml` file, so we started using `conda-build` directly to do this preprocessing. However, the effect is some sections may appear blank. For instance, if one parses this `meta.yaml` file on Linux, one will have an empty `source` section as the selectors drop out everything else. This results in an error from `conda-build`. As a result, the team update script fails with an error like that below. To fix this we have started adding selectors for the `source` key or other keys if they will not include content on some platforms. We should probably starting working with `conda-build` to be more accommodating of this behavior.

```
Traceback (most recent call last):
  File "/home/travis/build/conda-forge/conda-forge.github.io/scripts/update_teams.py", line 79, in <module>
    meta = MetaData(os.path.dirname(recipe))
  File "/home/travis/conda/tmp_envs/4a053950f5cbeca16023/lib/python3.5/site-packages/conda_build/metadata.py", line 334, in __init__
    self.parse_again(permit_undefined_jinja=True)
  File "/home/travis/conda/tmp_envs/4a053950f5cbeca16023/lib/python3.5/site-packages/conda_build/metadata.py", line 345, in parse_again
    self.meta = parse(self._get_contents(permit_undefined_jinja))
  File "/home/travis/conda/tmp_envs/4a053950f5cbeca16023/lib/python3.5/site-packages/conda_build/metadata.py", line 153, in parse
    (field, res[field].__class__.__name__))
RuntimeError: The source field should be a dict, not str
CalledProcessError: Command '['python', '/home/travis/build/conda-forge/conda-forge.github.io/scripts/update_teams.py', './feedstocks_repo/feedstocks']' returned non-zero exit status 1
```

cc @msarahan @pelson
